### PR TITLE
Automatic dependency management using Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates: 
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule: 
+      interval: "weekly"


### PR DESCRIPTION
Dependabot will look for dependencies that should be updated weekly and open a PR.
AFAIK, we are not bound to any specific package versions, but if so, we can configure dependabot to ignore them using the `ignore` key.

More config options can be found [here](https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates#configuration-options-for-updates).